### PR TITLE
Use more standard prototypical inheritance for toXml methods

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,16 @@
 var xml = require('xml');
 
-var defaultToXmlMethod = function() {
+/**
+  Base class for classes that will generate XML for one entity node. Subclasses
+  should override the `toXmlObj` method.
+*/
+var XmlEntityGenerator = function() { };
+
+XmlEntityGenerator.prototype.toXmlObj = function() {
+  console.error('Not implemented');
+};
+
+XmlEntityGenerator.prototype.toXml = function() {
   var xmlObj = this.toXmlObj();
 
   if (!xmlObj) {
@@ -10,16 +20,27 @@ var defaultToXmlMethod = function() {
   return xml(xmlObj);
 };
 
-var defaultListToXmlMethod = function() {
-  var listXml = [];
-  var list = this.toXmlObjList();
 
-  for (var i = 0; i < list.length; i++) {
-    listXml.push(xml(list[i]));
+/**
+  Base class for classes that will generate XML for a list of entity nodes. Subclasses
+  should override the `toXmlObjList` method.
+*/
+var XmlEntityListGenerator = function() { };
+
+XmlEntityListGenerator.prototype.toXmlObjList = function() {
+  console.error('Not implemented');
+};
+
+XmlEntityListGenerator.prototype.toXml = function() {
+  var xmlObjList = this.toXmlObjList();
+
+  if (xmlObjList.length <= 0) {
+    return '';
   }
 
-  return listXml.join('');
+  return xml(xmlObjList);
 };
+
 
 var addXmlObjToList = function(list, key, value) {
   if (value) {
@@ -122,10 +143,7 @@ var AuthorizeCustomer = function(options) {
   this.paymentProfiles    = new AuthorizePaymentProfiles(options.paymentProfiles);
 };
 
-/*
-@returns {String} XML output for AuthorizeCustomer.
-*/
-AuthorizeCustomer.prototype.toXml = defaultToXmlMethod;
+AuthorizeCustomer.prototype = new XmlEntityGenerator();
 
 AuthorizeCustomer.prototype.toXmlObj = function() {
   var xmlObj = { profile: [] };
@@ -178,10 +196,7 @@ var AuthorizeCustomerBasic = function(options) {
   this.customerProfileId  = options.customerProfileId || '';
 };
 
-/*
-@returns {String} XML output for AuthorizeCustomerBasic.
-*/
-AuthorizeCustomerBasic.prototype.toXml = defaultToXmlMethod;
+AuthorizeCustomerBasic.prototype = new XmlEntityGenerator();
 
 AuthorizeCustomerBasic.prototype.toXmlObj = function() {
   var xmlObj = { profile: [] };
@@ -248,10 +263,7 @@ var AuthorizeBillingAddress = function(addresses) {
   this.length = this.bin.length;
 };
 
-/*
-@returns {String} XML output for AuthorizeBillingAddress.
-*/
-AuthorizeBillingAddress.prototype.toXml = defaultListToXmlMethod;
+AuthorizeBillingAddress.prototype = new XmlEntityListGenerator();
 
 AuthorizeBillingAddress.prototype.toXmlObjList = function() {
   var list = [];
@@ -317,10 +329,7 @@ var AuthorizeShippingAddress = function(addresses) {
   this.length = this.bin.length;
 };
 
-/*
-@returns {String} XML output for AuthorizeShippingAddress.
-*/
-AuthorizeShippingAddress.prototype.toXml = defaultListToXmlMethod;
+AuthorizeShippingAddress.prototype = new XmlEntityListGenerator();
 
 AuthorizeShippingAddress.prototype.toXmlObj = function() {
   var list = this.toXmlObjList();
@@ -396,10 +405,7 @@ var AuthorizeAddress = function(address) {
   this.customerAddressId  = address.customerAddressId || '';
 };
 
-/*
-@returns {String} XML output for AuthorizeAddress.
-*/
-AuthorizeAddress.prototype.toXml = defaultListToXmlMethod;
+AuthorizeAddress.prototype = new XmlEntityListGenerator();
 
 AuthorizeAddress.prototype.toXmlObjList = function() {
   var xmlObjList = [];
@@ -507,10 +513,7 @@ var AuthorizePaymentProfiles = function(profiles) {
   this.length = this.bin.length;
 };
 
-/*
-@returns {String} XML output for AuthorizePaymentProfiles.
-*/
-AuthorizePaymentProfiles.prototype.toXml = defaultListToXmlMethod;
+AuthorizePaymentProfiles.prototype = new XmlEntityListGenerator();
 
 AuthorizePaymentProfiles.prototype.toXmlObjList = function() {
   var list = [];
@@ -616,10 +619,7 @@ var AuthorizePaymentProfile = function(profiles) {
   this.length = this.bin.length;
 };
 
-/*
-@returns {String} XML output for AuthorizePaymentProfile.
-*/
-AuthorizePaymentProfile.prototype.toXml = defaultListToXmlMethod;
+AuthorizePaymentProfile.prototype = new XmlEntityListGenerator();
 
 AuthorizePaymentProfile.prototype.toXmlObjList = function() {
   if (this.bin.length < 1) {
@@ -751,10 +751,7 @@ var AuthorizePayment = function(options) {
   this.length = this.bin.length;
 };
 
-/*
-@returns {String} XML output for AuthorizePayment.
-*/
-AuthorizePayment.prototype.toXml = defaultToXmlMethod;
+AuthorizePayment.prototype = new XmlEntityGenerator();
 
 AuthorizePayment.prototype.toXmlObj = function() {
   var xmlObj = { payment: [] };
@@ -835,10 +832,7 @@ var AuthorizePaymentSimple = function(options) {
   this.length = this.bin.length;
 };
 
-/*
-@returns {String} XML output for AuthorizePaymentSimple.
-*/
-AuthorizePaymentSimple.prototype.toXml = defaultListToXmlMethod;
+AuthorizePaymentSimple.prototype = new XmlEntityListGenerator();
 
 AuthorizePaymentSimple.prototype.toXmlObjList = function() {
   var list = [];
@@ -970,10 +964,7 @@ var AuthorizeTransaction = function(options) {
   this.approvalCode              = options.approvalCode || '';
 };
 
-/*
-@returns {String} XML output for AuthorizeTransaction.
-*/
-AuthorizeTransaction.prototype.toXml = defaultListToXmlMethod;
+AuthorizeTransaction.prototype = new XmlEntityListGenerator();
 
 AuthorizeTransaction.prototype.toXmlObjList = function() {
   var list = [];
@@ -1035,10 +1026,7 @@ var AuthorizeDuty = function(options) {
   this.length = Object.keys(options).filter(function(o) { return !!options[o]; }).length;
 };
 
-/*
-@returns {String} XML output for AuthorizeDuty.
-*/
-AuthorizeDuty.prototype.toXml = defaultToXmlMethod;
+AuthorizeDuty.prototype = new XmlEntityGenerator();
 
 AuthorizeDuty.prototype.toXmlObj = function() {
   if (this.length < 1) {
@@ -1089,10 +1077,7 @@ var AuthorizeOrder = function(options) {
   this.length = Object.keys(options).filter(function(o) { return !!options[o]; }).length;
 };
 
-/*
-@returns {String} XML output for AuthorizeOrder.
-*/
-AuthorizeOrder.prototype.toXml = defaultToXmlMethod;
+AuthorizeOrder.prototype = new XmlEntityGenerator();
 
 AuthorizeOrder.prototype.toXmlObj = function() {
   if (this.length < 1) {
@@ -1143,10 +1128,7 @@ var AuthorizeShipping = function(options) {
   this.length = Object.keys(options).filter(function(o) { return !!options[o]; }).length;
 };
 
-/*
-@returns {String} XML output for AuthorizeShipping.
-*/
-AuthorizeShipping.prototype.toXml = defaultToXmlMethod;
+AuthorizeShipping.prototype = new XmlEntityGenerator();
 
 AuthorizeShipping.prototype.toXmlObj = function() {
   if (this.length < 1) {
@@ -1198,10 +1180,7 @@ var AuthorizeTax = function(options) {
   this.length = Object.keys(options).filter(function(o) { return !!options[o]; }).length;
 };
 
-/*
-@returns {String} XML output for AuthorizeTax.
-*/
-AuthorizeTax.prototype.toXml = defaultToXmlMethod;
+AuthorizeTax.prototype = new XmlEntityGenerator();
 
 AuthorizeTax.prototype.toXmlObj = function() {
   if (this.length < 1) {
@@ -1261,10 +1240,7 @@ var AuthorizeLineItems = function(options) {
   this.length = this.bin.length;
 };
 
-/*
-@returns {String} XML output for AuthorizeLineItems.
-*/
-AuthorizeLineItems.prototype.toXml = defaultListToXmlMethod;
+AuthorizeLineItems.prototype = new XmlEntityListGenerator();
 
 AuthorizeLineItems.prototype.toXmlObjList = function() {
   var list = [];
@@ -1320,10 +1296,7 @@ var AuthorizeCreditCard = function(options) {
   this.length         = !this.cardNumber ? 0 : 1;
 };
 
-/*
-@returns {String} XML output for AuthorizeCreditCard.
-*/
-AuthorizeCreditCard.prototype.toXml = defaultToXmlMethod;
+AuthorizeCreditCard.prototype = new XmlEntityGenerator();
 
 AuthorizeCreditCard.prototype.toXmlObj = function() {
   if (!this.cardNumber) {
@@ -1381,10 +1354,7 @@ var AuthorizeBankAccount = function(options) {
   this.length         = !this.accountType ? 0 : 1;
 };
 
-/*
-@returns {String} XML output for AuthorizeBankAccount.
-*/
-AuthorizeBankAccount.prototype.toXml = defaultToXmlMethod;
+AuthorizeBankAccount.prototype = new XmlEntityGenerator();
 
 AuthorizeBankAccount.prototype.toXmlObj = function() {
   if (!this.accountNumber) {
@@ -1448,10 +1418,7 @@ var AuthorizePaymentSchedule = function(options) {
   this.length = (!!options.interval.length ? 1 : 0);
 };
 
-/*
-@returns {String} XML output for AuthorizePaymentSchedule.
-*/
-AuthorizePaymentSchedule.prototype.toXml = defaultToXmlMethod;
+AuthorizePaymentSchedule.prototype = new XmlEntityGenerator();
 
 AuthorizePaymentSchedule.prototype.toXmlObj = function() {
   if (this.length < 1) {
@@ -1608,10 +1575,7 @@ var AuthorizeSubscription = function(options) {
   this.shipTo               = new AuthorizeShippingAddress(options.shipTo);
 };
 
-/*
-@returns {String} XML output for AuthorizeSubscription.
-*/
-AuthorizeSubscription.prototype.toXml = defaultToXmlMethod;
+AuthorizeSubscription.prototype = new XmlEntityGenerator();
 
 AuthorizeSubscription.prototype.toXmlObj = function() {
   var xmlObj = { subscription: [] };


### PR DESCRIPTION
After sleeping on it, it dawned on me that the implementation of the `toXml` methods could be done in a more prototypical fashion. It's more a style thing and doesn't really make much difference functionality wise, so feel free to disregard this pull request if you like.
